### PR TITLE
[TASK] add composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,9 @@
+{
+	"name": "georgringer/autoswitchtolistview",
+	"version": "0.0.4",
+	"description": "Autoswitch to list view",
+	"type": "typo3-cms-extension",
+	"replace": {
+		"autoswitchtolistview": "*"
+	}
+}


### PR DESCRIPTION
have not added typo3-cms-core because this extension might be used prior to 6.2
